### PR TITLE
CORE-2843 Sql wrong lexical analysis for string literals - escaped si…

### DIFF
--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -46,7 +46,7 @@ TOKEN:
 |	< S_IDENTIFIER: ( <LETTER> | <ADDITIONAL_LETTERS> )+ ( <DIGIT> | <LETTER> | <ADDITIONAL_LETTERS> | <SPECIAL_CHARS> )* >
 | 	< #LETTER: ["a"-"z", "A"-"Z", "_", "$"] >
 |   < #SPECIAL_CHARS: "$" | "_" | "#" | "@" >
-|   < S_CHAR_LITERAL: "'" (~["'"])* "'" ("'" (~["'"])* "'")*>
+|   < S_CHAR_LITERAL: "'" (~["'"]|"\'")* "'" ("'" (~["'"]|"\'")* "'")*>
 |   < S_QUOTED_IDENTIFIER: "\"" (~["\n","\r","\""])+ "\"" | ("`" (~["\n","\r","`"])+ "`") | ( "[" ~["0"-"9","]"] (~["\n","\r","]"])* "]" ) >
 |    <EMPTY_QUOTE: "\"" "\"">
 


### PR DESCRIPTION
…ngle quotes are misparsed

S_CHAR_LITERAL now supports 'literal', 'double quoted ''literal''' and 'literal with \'escaped single quote\''